### PR TITLE
2021-11-21 updating postgresql

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   postgresql:
-    image: postgres:13.3
+    image: postgres:13.4
     container_name: great-escape-api-monolith_postgresql
     # volumes:
     #     - ~/volumes/jhipster/GreatEscapeApiMonolith/postgresql/:/var/lib/postgresql/data/

--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -19,7 +19,7 @@ spring:
   datasource:
     type: com.zaxxer.hikari.HikariDataSource
     driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
-    url: jdbc:tc:postgresql:13.3:///test?TC_TMPFS=/testtmpfs:rw
+    url: jdbc:tc:postgresql:13.4:///test?TC_TMPFS=/testtmpfs:rw
     username: test
     password: test
     hikari:


### PR DESCRIPTION
Reason to update: GCP updated the PostgreSQL version on its side (exactly up to 13.4)